### PR TITLE
Added development version of Django to requirements file

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ whoosh
 -e git://github.com/jbalogh/jingo.git#egg=jingo
 -e git://github.com/toastdriven/django-haystack.git@master#egg=django-haystack
 bleach
+-e svn+http://code.djangoproject.com/svn/django/trunk#egg=Django


### PR DESCRIPTION
You need to have the development version there as the logging config isn't valid otherwise.  Without it in requirements, one of the dependencies installs django1.3
