### PR TITLE
32. Disable YouTube's related videos at the end

### DIFF
--- a/apps/videos/templates/videos/video_display.html
+++ b/apps/videos/templates/videos/video_display.html
@@ -23,7 +23,8 @@
           video_url: "{{ v.source_url }}",
           video_config: {
             width: 640,
-            height: 480
+            height: 480,
+            rel: 0
           }
         })
       </script>


### PR DESCRIPTION
This fixes a problem with Universal Subtitles. When clicking on a
related video, the subtitles stay the same from the video before.

Closes #32
