### PR TITLE
Generalize the float fix in the video display

### DIFF
--- a/apps/videos/templates/videos/video_display.html
+++ b/apps/videos/templates/videos/video_display.html
@@ -16,10 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -#}
 {% macro display(v) -%}
-  <div class="videobox-inner">
+  <div class="videobox-inner clearfix"> {# Fix floats in unisubs widget that are not cleared #}
     {% if v.source_url and 'youtube' in v.source_url %}
-      {# Fix floats in unisubs widget that are not cleared #}
-      <div class="clearfix">
       <script type="text/javascript" src="http://s3.www.universalsubtitles.org/embed.js">
         ({
           video_url: "{{ v.source_url }}",
@@ -30,7 +28,6 @@
           }
         })
       </script>
-      </div>
     {% elif v.embed %}
       {{ v.embed|safe }}
     {% else %}


### PR DESCRIPTION
Some videos may have embed code that itself uses unisubs again, thus
leaving uncleared floats. Just wrap the whole container now to be on the
safe side.
## 

Sorry, haven't thought of the possibility that some videos have embed code that uses the unisubs widget. This time, it should work no matter what.
