### PR TITLE
Add video count to category page. Fixes #19

### DIFF
--- a/apps/videos/templates/videos/category.html
+++ b/apps/videos/templates/videos/category.html
@@ -29,8 +29,7 @@
 <div class="page-header">
   <h1>{{ category.title }}
     <small>
-      {% set video_count = category.video_set.live()|length %}
-      ({{ video_count }} Video{{ 's' if video_count != 1 else '' }})
+      ({{ videos|length }} Video{{ 's' if videos|length != 1 else '' }})
       {% if user.is_staff %}
         <a href="{{ url('admin:videos_category_change', category.id) }}"><i class="icon-edit"></i> edit</a>
       {% endif %}


### PR DESCRIPTION
It looks like this now:

![](http://cl.ly/GX4Q/Screen%20Shot%202012-05-10%20at%208.29.05%20PM.png)

I didn't use "total videos: xx" like you mentioned in #19, but it would be an easy change if you'd rather it that way.
