### PR TITLE
Add venv and whoosh_index to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 .env
 *.db
 richard/settings_local.py
+venv
+whoosh_index
 
 docs/_build/


### PR DESCRIPTION
Developers will encounter both of these directories, and their checkout will almost always be dirty without this change.
