### PR TITLE
121. Display related URLs on the video page

### DIFF
--- a/richard/settings.py
+++ b/richard/settings.py
@@ -158,7 +158,8 @@ JINGO_EXCLUDE_APPS = (
     'registration',
 )
 
-JINGO_CONFIG = {
+JINJA_CONFIG = {
+    'extensions': ['jinja2.ext.with_']
 }
 
 INSTALLED_APPS = (

--- a/richard/videos/admin.py
+++ b/richard/videos/admin.py
@@ -18,7 +18,8 @@ from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.utils.translation import ugettext_lazy as _
 
-from richard.videos.models import Video, Category, Speaker, CategoryKind, Tag
+from richard.videos.models import (Video, Category, Speaker, CategoryKind, Tag,
+                                   RelatedUrl)
 
 
 class WhiteboardFilter(SimpleListFilter):
@@ -46,6 +47,10 @@ class CategoryKindAdmin(admin.ModelAdmin):
 admin.site.register(CategoryKind, CategoryKindAdmin)
 
 
+class RelatedUrlInline(admin.TabularInline):
+    model = RelatedUrl
+
+
 class VideoAdmin(admin.ModelAdmin):
     date_hierarchy = 'recorded'
     list_display = ('title', 'category', 'whiteboard', 'state')
@@ -55,6 +60,7 @@ class VideoAdmin(admin.ModelAdmin):
     filter_horizontal = ('tags', 'speakers',)
     save_on_top = True
     prepopulated_fields = {'slug': ('title',)}
+    inlines = [RelatedUrlInline]
 
 
 admin.site.register(Video, VideoAdmin)

--- a/richard/videos/templates/search/indexes/videos/video_text.txt
+++ b/richard/videos/templates/search/indexes/videos/video_text.txt
@@ -17,3 +17,7 @@
 {% for t in object.tags.all() %}
   {{ t.tag }}
 {% endfor %}
+
+{% for u in object.related_urls.all() %}
+  {{ u.url }} {{ u.description }}
+{% endfor %}

--- a/richard/videos/templates/videos/video.html
+++ b/richard/videos/templates/videos/video.html
@@ -50,6 +50,19 @@
         {{ v.description|safe }}
       </div>
     {% endif %}
+
+    {% with urls = v.related_urls.all() %}
+      {% if urls %}
+        <div class="section">
+          <h2>Related URLs</h2>
+          <ul>
+          {% for u in urls %}
+            <li><a href="{{ u.url }}">{% if u.description %}{{ u.description }} ({{ u.url }}){% else %}{{ u.url }}{% endif %}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    {% endwith %}
   </div>
 
 


### PR DESCRIPTION
The model was already there, but we were missing a way to add URLs to a
video and displaying them. They can now be added in the admin when
modifying a video.
## 

Did all the changes mentioned in the issue. I've included the URL itself in the search index, however I'm not sure how useful that is.
