### PR TITLE
Add process to review suggestions

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -166,6 +166,11 @@ Here are additional configuration settings:
     don't know whether it was the software or the service. So it's
     either called Amara or Universal Subtitles.
 
+``SPAM_WORDS``
+
+    Set this to a list of spam words in order to automatically check
+    newly submitted suggestion for spam and mark the items as such.
+
 
 ``VIDEO_THUMBNAIL_SIZE``
 

--- a/richard/settings.py
+++ b/richard/settings.py
@@ -262,12 +262,15 @@ LOGGING = {
     }
 }
 
+# Modify this list to prevent spam messages in public suggestions
+SPAM_WORDS = []
+
 try:
-    from richard.settings_local import *    
+    from richard.settings_local import *
 except ImportError:
     pass
 
-import sys
+
 if 'test' in sys.argv:
     try:
         from richard.settings_test import *

--- a/richard/suggestions/admin.py
+++ b/richard/suggestions/admin.py
@@ -19,13 +19,19 @@ from django.contrib import admin
 from richard.suggestions.models import Suggestion
 
 
+def mark_as_spam(modeladmin, request, queryset):
+    queryset.update(state=Suggestion.STATE_SPAM,
+                    is_reviewed=True)
+
+
 class SuggestionAdmin(admin.ModelAdmin):
     date_hierarchy = 'submitted'
-    list_display = ('state', 'name', 'url', 'submitted', 'resolved',)
-    list_filter = ('state',)
+    list_display = ('state', 'is_reviewed', 'name', 'url', 'submitted', 'resolved',)
+    list_filter = ('state', 'is_reviewed',)
     search_fields = ('name', 'url',)
     radio_fields = {'state': admin.HORIZONTAL}
     exclude = ('resolved',)
+    actions = [mark_as_spam]
 
 
 admin.site.register(Suggestion, SuggestionAdmin)

--- a/richard/suggestions/migrations/0002_auto__add_field_suggestion_is_reviewed.py
+++ b/richard/suggestions/migrations/0002_auto__add_field_suggestion_is_reviewed.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Suggestion.is_reviewed'
+        db.add_column('suggestions_suggestion', 'is_reviewed',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Suggestion.is_reviewed'
+        db.delete_column('suggestions_suggestion', 'is_reviewed')
+
+
+    models = {
+        'suggestions.suggestion': {
+            'Meta': {'object_name': 'Suggestion'},
+            'comment': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_reviewed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'resolution': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'resolved': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'submitted': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'whiteboard': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['suggestions']

--- a/richard/suggestions/migrations/0003_modify_existing_resolved.py
+++ b/richard/suggestions/migrations/0003_modify_existing_resolved.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        RESOLVED_STATES = (2, 3)
+        Suggestion = orm['suggestions.Suggestion']
+        Suggestion.objects.filter(
+            resolution__in=RESOLVED_STATES).update(
+                is_reviewed=True)
+        # Note: Remember to use orm['appname.ModelName'] rather than "from appname.models..."
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        'suggestions.suggestion': {
+            'Meta': {'object_name': 'Suggestion'},
+            'comment': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_reviewed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'resolution': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '128', 'blank': 'True'}),
+            'resolved': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'submitted': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'}),
+            'whiteboard': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['suggestions']
+    symmetrical = True

--- a/richard/suggestions/models.py
+++ b/richard/suggestions/models.py
@@ -61,6 +61,7 @@ class Suggestion(models.Model):
 
     submitted = models.DateTimeField(auto_now_add=True)
     resolved = models.DateTimeField(blank=True, null=True)
+    is_reviewed = models.BooleanField(default=False)
 
     def __unicode__(self):
         return self.name

--- a/richard/suggestions/templates/suggestions/suggestions_list.html
+++ b/richard/suggestions/templates/suggestions/suggestions_list.html
@@ -133,7 +133,7 @@
       <div class="control-group">
         <div class="controls">
           <p>
-            After you submit your suggestions, you can check this page
+            We will review your suggestions before it is made public, you can check this page
             for updates.
           </p>
           <button type="submit" class="btn btn-primary">Submit</button>

--- a/richard/suggestions/tests/test_views.py
+++ b/richard/suggestions/tests/test_views.py
@@ -26,10 +26,22 @@ from richard.suggestions.tests import suggestion
 class TestSuggestions(TestCase):
     """Tests for the ``suggestions`` app."""
 
-    def test_list(self):
+    def test_not_reviewed_list(self):
         """Test the view of the listing of all suggestions."""
         url = reverse('suggestions-list')
         s = suggestion(save=True)
+
+        resp = self.client.get(url)
+        eq_(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'suggestions/suggestions_list.html')
+        assert s.name not in resp.content
+
+    def test_reviewed_list(self):
+        """Test the view of the listing of all suggestions."""
+        url = reverse('suggestions-list')
+        s = suggestion(save=True)
+        s.is_reviewed = True
+        s.save()
 
         resp = self.client.get(url)
         eq_(resp.status_code, 200)

--- a/richard/suggestions/utils.py
+++ b/richard/suggestions/utils.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from richard.suggestions.models import Suggestion
+
+
+def mark_if_spam(suggestion):
+    """
+    Accepts a suggestion instance and checks it's name
+    and comment fields for spam words.
+
+    If any words are found, it marks the item's state as spam.
+    """
+    # parse suggestion text into a list of containing only unique alphnum words
+    s = ' '.join([suggestion.name, suggestion.comment])
+    unique_words = set(''.join(c for c in s if c.isalnum() or c.isspace()).split())
+
+    for word in settings.SPAM_WORDS:
+        if word in unique_words:
+            suggestion.state = Suggestion.STATE_SPAM
+            suggestion.save()
+            break
+    return suggestion

--- a/richard/suggestions/views.py
+++ b/richard/suggestions/views.py
@@ -18,6 +18,7 @@ from django.shortcuts import render, redirect
 
 from richard.suggestions.forms import SuggestionForm
 from richard.suggestions.models import Suggestion
+from richard.suggestions.utils import mark_if_spam
 
 
 def suggestions(request):
@@ -25,15 +26,18 @@ def suggestions(request):
     if request.method == 'POST':
         form = SuggestionForm(request.POST)
         if form.is_valid():
-            form.save()
+            obj = form.save()
+            mark_if_spam(obj)
             return redirect('suggestions-list')
     else:
         form = SuggestionForm()
 
     open_objs = Suggestion.objects.filter(
-        state__in=Suggestion.OPEN_STATES)
+        state__in=Suggestion.OPEN_STATES,
+        is_reviewed=True)
     resolved_objs = Suggestion.objects.filter(
-        state__in=Suggestion.RESOLVED_STATES)
+        state__in=Suggestion.RESOLVED_STATES,
+        is_reviewed=True)
 
     ret = render(
         request, 'suggestions/suggestions_list.html',


### PR DESCRIPTION
This is the simplest I could make review process for adding new suggestions.

Basically, this will be the flow:
1. A user adding a suggestion will have it created with is_reviewed false.
2. An admin will then occasionally go over the suggestions while marking items reviewed as such.
3. The admin may also filter items that have yet to be reviewed and also mark multiple items as spam, using the helpful "mark as spam" custom admin action.
- bonus: every suggestion that is saved with a state other than new will automatically be marked as reviewed, thus removing the need to explicitly mark items as reviewed.
