### PR TITLE
video count display problem in category page

### DIFF
--- a/richard/videos/templates/videos/category.html
+++ b/richard/videos/templates/videos/category.html
@@ -55,10 +55,12 @@
           No description.
         {% endif %}
       </dd>
-      <dt>Date:</dt>
-      <dd>
-        {{ category.start_date|datetime }}
-      </dd>
+      {% if category.start_date %}
+        <dt>Date:</dt>
+        <dd>
+          {{ category.start_date|datetime }}
+        </dd>
+      {% endif %}
       <dt>Number of videos:</dt>
       <dd>
         {{ videos|length }}


### PR DESCRIPTION
http://pyvideo.org/category/34/chicago-djangonauts
the 1 render next to Date, not videos.
Seems the empty dd after Date is the problem.
If there is no date, no point in "Date:none" so just drop the whole thing.
