### PR TITLE
Fix url of "Contributor's Guide"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ you in the future? Does it sound like something you want to be
 involved in?
 
 I'd love to have help! We have a special `Contributor's Guide
-<http://richard.rtfd.org/en/latest/contributors/dev_contribute.html>`_
+<http://richard.readthedocs.org/en/latest/contributors/dev_contribute.html>`_
 in the richard manual that covers how to get richard set up for
 hacking on it, the kinds of things we need help on, and all the sorts
 of things you'd want to know about the project.


### PR DESCRIPTION
The original url link to rtfd.org which ends up in the following page:

![screen shot 2013-07-12 at 5 29 27 pm](https://f.cloud.github.com/assets/116473/787271/a413bc82-ead5-11e2-9cf3-97118091bd5a.png)

Changing rftd to readthedocs fix the problem.
