### PR TITLE
fixes template changes now that we don't use jinja

### DIFF
--- a/richard/base/context_processors.py
+++ b/richard/base/context_processors.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.conf import settings
 from richard.sitenews.models import Notification
 
 
@@ -21,5 +22,6 @@ def base(request):
     notifications = Notification.get_live_notifications()
 
     return {
+        'settings': settings,
         'notifications': notifications,
         }

--- a/richard/base/templates/404.html
+++ b/richard/base/templates/404.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load url from future %}
 {% block content %}
 

--- a/richard/base/templates/500.html
+++ b/richard/base/templates/500.html
@@ -1,4 +1,4 @@
-{#
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
+{% endcomment %}
 <html>
 <title>Server Error</title>
 <body>

--- a/richard/base/templates/base.html
+++ b/richard/base/templates/base.html
@@ -1,4 +1,4 @@
-{#
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,16 +14,18 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
+{% endcomment %}
+
 {% load browserid %}
 {% load md %}
 {% load page_title %}
 {% load url from future %}
+{% load staticfiles %}
 <!DOCTYPE html>
 <html>
 <head>
-  <link rel="stylesheet" href="{{ settings.STATIC_URL }}bootstrap/css/bootstrap.min.css">
-  <link rel="stylesheet" href="{{ settings.STATIC_URL }}css/richard.css">
+  <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+  <link rel="stylesheet" href="{% static 'css/richard.css' %}">
   <link rel="search" type="application/opensearchdescription+xml" title="{{ settings.SITE_TITLE }} search" href="{% url 'videos-opensearch' %}">
   <title>{% block title %}{{ settings.SITE_TITLE }}{% endblock %}</title>
 {% if meta %}
@@ -97,8 +99,10 @@
     </div>
   {% endif %}
 
-  {# TODO: messages #}
-  {# TODO: breadcrumbs #}
+  {% comment %}
+  TODO: messages
+  TODO: breadcrumbs
+  {% endcomment %}
 
   {% block content %}{% endblock %}
 
@@ -112,13 +116,13 @@
 {% endblock %}
 
 {% block site_js %}
-<script type="text/javascript" src="{{ settings.STATIC_URL }}js/jquery-1.7.2.min.js"></script>
-<script type="text/javascript" src="{{ settings.STATIC_URL }}bootstrap/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="{% static 'js/jquery-1.7.2.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'bootstrap/js/bootstrap.min.js' %}"></script>
   {% if not settings.BROWSERID_AUTOLOGIN %}
-    <script type="text/javascript" src="{{ settings.STATIC_URL }}browserid/browserid.js"></script>
+    <script type="text/javascript" src="{% static 'browserid/browserid.js' %}"></script>
     <script type="text/javascript" src="https://login.persona.org/include.js"></script>
   {% else %}
-    <script type="text/javascript" src="{{ settings.STATIC_URL }}js/browserid-mock.js"></script>
+    <script type="text/javascript" src="{% static 'js/browserid-mock.js' %}"></script>
   {% endif %}
 {% endblock %}
 </body>

--- a/richard/base/templates/home.html
+++ b/richard/base/templates/home.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load url from future %}
 {% block content %}
 
@@ -26,8 +26,7 @@
         <h1>{{ settings.SITE_TITLE }}</h1>
         <p>
           This site indexes videos that exist in various places and
-          makes them easier to find. {{ video_count }} video{{ 's' if
-          video_count != 1 else '' }} so far.
+          makes them easier to find. {{ video_count }} video{{ video_count|pluralize }} so far.
         </p>
         <p>
           <a class="btn btn-primary btn-large" href="{% url 'pages-page' page='about' %}">Learn more</a>

--- a/richard/base/templates/home_branded.html
+++ b/richard/base/templates/home_branded.html
@@ -1,4 +1,5 @@
-{#
+{% extends "home.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,5 +15,4 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "home.html" %}
+{% endcomment %}

--- a/richard/base/templates/login_failure.html
+++ b/richard/base/templates/login_failure.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load url from future %}
 {% block content %}
 

--- a/richard/base/templates/pages/about.html
+++ b/richard/base/templates/pages/about.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% block title %}{% page_title 'About' %}{% endblock %}
 {% block content %}

--- a/richard/base/templates/stats.html
+++ b/richard/base/templates/stats.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load url from future %}
 {% block title %}{% page_title 'Statistics' %}{% endblock %}

--- a/richard/sitenews/sampledata.py
+++ b/richard/sitenews/sampledata.py
@@ -19,8 +19,8 @@ from richard.sitenews.tests import sitenews
 
 def generate_sampledata(options):
     sitenews(title=u'Welcome to my index!',
-             summary=u'<p>I just created this site.</p>',
-             content=u'Yay!',
+             summary=u'I just created _this_ site.',
+             content=u'Yay! *hurrah!*',
              author=u'site admin',
              slug='first-post',
              save=True)

--- a/richard/sitenews/templates/sitenews/news.html
+++ b/richard/sitenews/templates/sitenews/news.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load md %}
 {% load url from future %}

--- a/richard/sitenews/templates/sitenews/news_list.html
+++ b/richard/sitenews/templates/sitenews/news_list.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load md %}
 {% load url from future %}

--- a/richard/suggestions/templates/suggestions/suggestions_list.html
+++ b/richard/suggestions/templates/suggestions/suggestions_list.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load url from future %}
 {% block title %}{% page_title 'Suggestions' %}{% endblock %}

--- a/richard/videos/templates/search/indexes/videos/video_text.txt
+++ b/richard/videos/templates/search/indexes/videos/video_text.txt
@@ -1,7 +1,7 @@
-{#
+{% comment %}
   this just tosses everything into the "text". should do analysis at
   some point as to whether that's a good idea.
-#}
+{% endcomment %}
 {{ object.title }}
 
 {{ object.summary }}

--- a/richard/videos/templates/videos/category.html
+++ b/richard/videos/templates/videos/category.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load md %}
 {% load page_title %}
 {% load url from future %}

--- a/richard/videos/templates/videos/category_feed_video.html
+++ b/richard/videos/templates/videos/category_feed_video.html
@@ -1,4 +1,4 @@
-{#
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
+{% endcomment %}
 {% load md %}
 {% if obj.description %}
   <p>Description</p>

--- a/richard/videos/templates/videos/category_list.html
+++ b/richard/videos/templates/videos/category_list.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load url from future %}
 {% block title %}{% page_title 'Categories' %}{% endblock %}

--- a/richard/videos/templates/videos/includes/video_summary.html
+++ b/richard/videos/templates/videos/includes/video_summary.html
@@ -1,4 +1,4 @@
-{#
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
+{% endcomment %}
 {% load md %}
 {% load url from future %}
 <div class="row section">

--- a/richard/videos/templates/videos/opensearch.xml
+++ b/richard/videos/templates/videos/opensearch.xml
@@ -1,4 +1,4 @@
-{#
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
+{% endcomment %}
 {% load url from future %}
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">

--- a/richard/videos/templates/videos/search.html
+++ b/richard/videos/templates/videos/search.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load url from future %}
 {% load video_summary %}

--- a/richard/videos/templates/videos/speaker.html
+++ b/richard/videos/templates/videos/speaker.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load page_title %}
 {% load url from future %}
 {% load video_summary %}

--- a/richard/videos/templates/videos/speaker_list.html
+++ b/richard/videos/templates/videos/speaker_list.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load batch %}
 {% load page_title %}
 {% load url from future %}

--- a/richard/videos/templates/videos/video.html
+++ b/richard/videos/templates/videos/video.html
@@ -1,4 +1,5 @@
-{#
+{% extends "base.html" %}
+{% comment %}
 # richard -- video index system
 # Copyright (C) 2012, 2013 richard contributors.  See AUTHORS.
 #
@@ -14,8 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#}
-{% extends "base.html" %}
+{% endcomment %}
 {% load duration %}
 {% load md %}
 {% load page_title %}


### PR DESCRIPTION
This commit fixes and improves a few things for the jinja removal.
- static urls can be constructed via the _static_ templatetag rather than being manually constructed
- words can be pluralized with the _pluralize_ templatetag
- comments use the _comment_ and _endcomment_ block
- django _settings_ has been is added back to the base context processor becuase its removal caused continual redirects to the home page due to continual requests being made to the browserid login.
