### PR TITLE
Fix browserid url prefix

### DIFF
--- a/richard/urls.py
+++ b/richard/urls.py
@@ -51,7 +51,7 @@ urlpatterns = patterns(
     url(r'^suggestions/', include('richard.suggestions.urls')),
     url(r'', include('richard.videos.urls')),
 
-    url(r'^browserid/', include('django_browserid.urls')),
+    url(r'', include('django_browserid.urls')),
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
In django-browserid 0.10 the "browserid" prefix was pulled into the library's urlconf.

See here: http://django-browserid.readthedocs.org/en/v0.10/user/quickstart.html#configuration
