### PR TITLE
Add ordering filter to videos API

### DIFF
--- a/docs/admin/api.rst
+++ b/docs/admin/api.rst
@@ -145,6 +145,15 @@ Videos
 
       $ curl -X GET 'http://example.com/api/v2/video/?category=pycon-us-2014'
 
+``GET /api/v2/video/?ordering=FOO``
+    Returns videos ordered by field FOO. The fields allowed in the
+    ordering filter are `added`, `recorded` and `title`. Reverse ordering
+    is specified by prefixing the field name with `-`
+
+    Example::
+
+      $ curl -X GET 'http://example.com/api/v2/video/?ordering=-added'
+
 ``POST /api/v2/video/``
     Creates a new video.
 

--- a/richard/videos/views.py
+++ b/richard/videos/views.py
@@ -27,6 +27,7 @@ from django.shortcuts import get_object_or_404, render
 from haystack.query import SearchQuerySet
 from rest_framework import generics
 from rest_framework import permissions
+from rest_framework import filters
 
 from richard.videos import models
 
@@ -315,6 +316,8 @@ class SpeakerListAPI(generics.ListAPIView):
 class VideoListCreateAPI(generics.ListCreateAPIView):
     serializer_class = models.VideoSerializer
     permission_classes = (IsAdminOrReadOnly,)
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = ('added', 'recorded', 'title')
 
     def get_queryset(self):
         if self.request.user.is_staff:


### PR DESCRIPTION
Allow to retrieve videos ordered by fields title/recorded/added.
