### PR TITLE
use dj-database-url because it is very handy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ requirements = [
     'django-browserid==0.10.1',
     'django-grappelli==2.5.2',
     'django-haystack==2.1.0',
+    'dj-database-url==0.3.0',
     'eadred==0.3',
     'Markdown==2.3.1',
     'requests==2.1.0',


### PR DESCRIPTION
I'd like to use dj-database-url because it makes life easier, like we discussed in irc.

at the moment, I cannot get `pip install . -e \[dev\]` to work, so don't accept this yet.
