### PR TITLE
slug length counter bumps slug over max_length limit

### DIFF
--- a/richard/videos/tests/test_api.py
+++ b/richard/videos/tests/test_api.py
@@ -273,7 +273,7 @@ class TestVideoPostAPI(TestAPIBase):
 
         vid = Video.objects.get(title=data['title'])
         eq_(vid.title, data['title'])
-        eq_(vid.slug, u'creating-delicious-apis-for-django-apps-since-201')
+        eq_(vid.slug, u'creating-delicious-apis-for-django-apps-since')
         eq_(list(vid.speakers.values_list('name', flat=True)), ['Guido'])
         eq_(sorted(vid.tags.values_list('tag', flat=True)),
             [u'api', u'django'])

--- a/richard/videos/tests/test_utils.py
+++ b/richard/videos/tests/test_utils.py
@@ -46,9 +46,11 @@ class TestGenerateUniqueSlug(TestCase):
     def test_unique_slug_length(self):
         """Generate slug less than slug max_length."""
         title = u'a' * 51
-        v = video(title=title, save=True)
-        v2 = video(title=title)
-        assert len(generate_unique_slug(v2, u'title', u'slug')) <= 50
+        for i in range(99):
+            video(title=title, save=True)
+        v = video(title=title)
+        slug = generate_unique_slug(v, u'title', u'slug')
+        assert len(slug) <= 50, 'slug [{}] is > 50'.format(slug)
 
     def test_unicode_title(self):
         v = video(title=u'Nebenläufige Programme mit Python')

--- a/richard/videos/utils.py
+++ b/richard/videos/utils.py
@@ -19,7 +19,10 @@ from django.utils.text import slugify
 
 
 def generate_unique_slug(obj, slug_from, slug_field='slug'):
-    text = getattr(obj, slug_from)[:49]
+    """ generate slug with a trailing counter to prevent name collision """
+    # slug field max_length is 50
+    # take 47 characters from the title, leaving 3 characters for the ending
+    text = getattr(obj, slug_from)[:46]
     root_text = text
     for i in range(100):
         slug = slugify(text_type(text))


### PR DESCRIPTION
When creating multiple videos with the same title, the unique counter appended to the slug bumps the entire thing over the max_length of 50 chars. related to #249
