### PR TITLE
Constrain large images in video summary/description

### DIFF
--- a/richard/base/static/css/richard.css
+++ b/richard/base/static/css/richard.css
@@ -72,3 +72,8 @@ div#video-summary-content .video-summary .thumbnail-data {
 div#video-summary-content .video-summary .video-summary-data {
   margin: 3px 0 0 204px;
 }
+
+.video-details-summary img,
+.video-details-description img {
+  max-width: 100%;
+}

--- a/richard/videos/templates/videos/video.html
+++ b/richard/videos/templates/videos/video.html
@@ -80,7 +80,7 @@
     {% if v.summary %}
       <div class="section">
         <h4>Summary</h4>
-        <div property="description">{{ v.summary|md|safe }}</div>
+        <div class="video-details-summary" property="description">{{ v.summary|md|safe }}</div>
         <meta property="caption" content="{{ v.summary|md|safe }}"/>
       </div>
     {% endif %}
@@ -99,7 +99,7 @@
     {% if v.description %}
       <div class="section">
         <h4>Description</h4>
-        {{ v.description|md|safe }}
+        <div class="video-details-description">{{ v.description|md|safe }}</div>
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Images might be larger than the summary/description container and will
stick out on the right. With this change images can be at most the width
of the container they are in.
