### PR TITLE
Link to category metadata only when API is enabled

### DIFF
--- a/richard/videos/templates/videos/category.html
+++ b/richard/videos/templates/videos/category.html
@@ -68,10 +68,12 @@
       <dd>
         {{ videos|length }}
       </dd>
-      <dt>Metadata</dt>
-      <dd>
-        <a href="{% url 'category-api-view' category.slug %}">JSON</a>
-      </dd>
+      {% if settings.API %}
+        <dt>Metadata</dt>
+        <dd>
+          <a href="{% url 'category-api-view' category.slug %}">JSON</a>
+        </dd>
+      {% endif %}
     </dl>
   </div>
 </div>


### PR DESCRIPTION
By default settings.API is False, and API urls are not included. The url
reverse on the category page will fail. Fix it by showing it
conditionally, exactly how it is done on the video page.
