### PR TITLE
change suggestion ordering and fix template

### DIFF
--- a/richard/suggestions/templates/suggestions/suggestions_list.html
+++ b/richard/suggestions/templates/suggestions/suggestions_list.html
@@ -59,16 +59,16 @@
           {% for s in open_suggestions %}
             <tr>
               <td>
-                {% if s == 0 %}
-                  <span class="label">New</span>
-                {% elif s == 1 %}
+                {% if s.state == 0 %}
+                  <span class="label label-default">New</span>
+                {% elif s.state == 1 %}
                   <span class="label label-info">In progress</span>
-                {% elif s == 2 %}
+                {% elif s.state == 2 %}
                   <span class="label label-success">Completed</span>
-                {% elif s == 3 %}
+                {% elif s.state == 3 %}
                   <span class="label label-important">Rejected</span>
                 {% endif %}
-              <td/>
+              </td>
               <td>{{ s.name }}</td>
               <td>{{ s.whiteboard }}</td>
               <td>{{ s.submitted|date:"DATE_FORMAT" }}</td>
@@ -99,16 +99,16 @@
           {% for s in resolved_suggestions %}
             <tr>
               <td>
-                {% if s == 0 %}
-                  <span class="label">New</span>
-                {% elif s == 1 %}
+                {% if s.state == 0 %}
+                  <span class="label label-default">New</span>
+                {% elif s.state == 1 %}
                   <span class="label label-info">In progress</span>
-                {% elif s == 2 %}
+                {% elif s.state == 2 %}
                   <span class="label label-success">Completed</span>
-                {% elif s == 3 %}
+                {% elif s.state == 3 %}
                   <span class="label label-important">Rejected</span>
                 {% endif %}
-              <td/>
+              </td>
               <td>{{ s.name }}</td>
               <td>{{ s.resolution }}</td>
               <td>{{ s.submitted|date:"DATE_FORMAT" }}</td>

--- a/richard/suggestions/views.py
+++ b/richard/suggestions/views.py
@@ -39,10 +39,10 @@ def suggestions(request):
 
     open_objs = Suggestion.objects.filter(
         state__in=Suggestion.OPEN_STATES,
-        is_reviewed=True)
+        is_reviewed=True).order_by('-submitted')
     resolved_objs = Suggestion.objects.filter(
         state__in=Suggestion.RESOLVED_STATES,
-        is_reviewed=True)
+        is_reviewed=True).order_by('-resolved')
 
     ret = render(
         request, 'suggestions/suggestions_list.html',


### PR DESCRIPTION
The suggestions template had a few quirks that I fixed.

motivation... I've noticed that conference organizers sometimes ask for advice on how to submit requests, and was thinking about adding a helpful paragraph to go with the submit form. I started looking at the suggestion page and it had a few mistakes. I wanted to clear those up before proceeding.

new

![suggestions](https://cloud.githubusercontent.com/assets/529748/3971824/68b5b7d6-27d7-11e4-8bcd-80e47a55d322.png)

old

![current](https://cloud.githubusercontent.com/assets/529748/3971846/8f947112-27d7-11e4-9689-ff2f7b2e4eb7.png)
