### PR TITLE
Fix wsgi to use django-configurations framework

### DIFF
--- a/src/richard/config/wsgi.py
+++ b/src/richard/config/wsgi.py
@@ -36,7 +36,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "richard.settings")
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-from django.core.wsgi import get_wsgi_application
+from configurations.wsgi import get_wsgi_application
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.


### PR DESCRIPTION
In order to deploy the site with uwsgi we need to import `get_wsgi_application` from django-configurations rather than django, as explained in the http://django-configurations.readthedocs.org docs. 