### PR TITLE
Specify how to skip specific pre-commit hooks

### DIFF
--- a/docs/contributors/dev_hacking.rst
+++ b/docs/contributors/dev_hacking.rst
@@ -206,8 +206,10 @@ Install the hooks by running::
     $ pre-commit install
 
 The configuration of the hooks is done in ``.pre-commit-config.yaml`.
-To ignore the errors and proceed with the commit, use the
-``--no-verify`` option to the ``git commit`` command.
+To ignore all the errors and proceed with the commit, use the
+``--no-verify`` option to the ``git commit`` command. To ignore specifc
+hooks, you can specify a comma-separated list of hook ids (available in
+``.pre-commit-config.yaml``) in the environment variable ``SKIP``.
 
 
 Set up sample data (optional)


### PR DESCRIPTION
Some times instead of using the ``--no-verify`` flag which bypasses all checks, it is useful to skip specific pre-commit hooks for a commit. Document how to do this.