### PR TITLE
293. Document the missing packages required for lxml

### DIFF
--- a/docs/contributors/dev_hacking.rst
+++ b/docs/contributors/dev_hacking.rst
@@ -53,7 +53,9 @@ Debian::
           libxml2-dev \
           libxslt-dev \
           python-pip \
-          python-virtualenv
+          python-virtualenv \
+          libpython-dev \
+          libz-dev
 
 Fedora::
 
@@ -61,7 +63,9 @@ Fedora::
           libxml2-devel \
           libxslt-devel \
           python-pip \
-          python-virtualenv
+          python-virtualenv \
+          python-devel \
+          zlib-devel
 
 
 Python 3.3+
@@ -117,8 +121,7 @@ requirements::
         $ apt-get install \
             postgresql \
             build-essential \
-            libpq-dev \
-            python-dev
+            libpq-dev
 
     Then run in your virtual environment::
 


### PR DESCRIPTION
The python headers and zlib headers are required for lxml installation
but are not mentioned in dev_hacking.rst. Specify the names of the
Debian/Ubuntu and Fedora packages for those and remove python-dev package
from the requirements for using postgresql.