### PR TITLE
Add an additional parameter to the runserver command

### DIFF
--- a/docs/contributors/dev_hacking.rst
+++ b/docs/contributors/dev_hacking.rst
@@ -193,7 +193,7 @@ Run the server
 
 Run the server like this::
 
-    $ ./manage.py runserver --traceback
+    $ ./manage.py runserver 0.0.0.0:8000 --traceback # 0.0.0.0 allows access to the local Django dev server from other machines on the network.
 
 
 Then point your browser at ``http://localhost:8000/``.


### PR DESCRIPTION
This caused me some grief during configuration. See http://www.holeintheceiling.com/blog/2012/06/21/django-and-runserver-0-0-0-0/ for more information.
